### PR TITLE
Support for Custom Attributes within Source Code

### DIFF
--- a/Editor/Blocks/CustomCode/CustomBlock.cs
+++ b/Editor/Blocks/CustomCode/CustomBlock.cs
@@ -2,6 +2,8 @@ using System;
 using UnityEngine;
 using System.Collections.Generic;
 
+using UnityEngine.VFX;
+
 namespace UnityEditor.VFX.Block
 {
     [VFXInfo(category = "Custom")]
@@ -12,6 +14,14 @@ namespace UnityEditor.VFX.Block
         public struct AttributeDeclarationInfo
         {
             public string name;
+            public VFXAttributeMode mode;
+        }
+
+        [Serializable]
+        public struct CustomAttributeDeclarationInfo
+        {
+            public string name;
+            public CustomAttributeUtility.Signature type;
             public VFXAttributeMode mode;
         }
 
@@ -30,6 +40,9 @@ namespace UnityEditor.VFX.Block
         public VFXDataType CompatibleData = VFXDataType.Particle;
 
         public List<AttributeDeclarationInfo> Attributes = new List<AttributeDeclarationInfo>();
+
+        public List<CustomAttributeDeclarationInfo> CustomAttributes = new List<CustomAttributeDeclarationInfo>();
+
         public List<PropertyDeclarationInfo> Properties = new List<PropertyDeclarationInfo>();
 
         public bool UseTotalTime = false;
@@ -52,6 +65,11 @@ namespace UnityEditor.VFX.Block
             {
                 foreach (var info in Attributes)
                     yield return new VFXAttributeInfo(VFXAttribute.Find(info.name), info.mode);
+
+                foreach (var c in CustomAttributes) {
+                    VFXAttribute attr = new VFXAttribute(c.name, CustomAttributeUtility.GetValueType(c.type));
+                    yield return new VFXAttributeInfo(attr, c.mode);
+                }
 
                 if (UseRandom)
                     yield return new VFXAttributeInfo(VFXAttribute.Seed, VFXAttributeMode.ReadWrite);

--- a/Editor/Blocks/CustomCode/CustomBlockEditor.cs
+++ b/Editor/Blocks/CustomCode/CustomBlockEditor.cs
@@ -275,7 +275,6 @@ namespace UnityEditor.VFX.Block
             {
                 if (GUILayout.Button("Apply"))
                 {
-                    // TODO: load here the source code (as string) from the specified file
                     SourceCode.stringValue = source;
                     Apply();
                 }

--- a/Editor/Blocks/CustomCode/CustomBlockEditor.cs
+++ b/Editor/Blocks/CustomCode/CustomBlockEditor.cs
@@ -14,6 +14,7 @@ namespace UnityEditor.VFX.Block
         SerializedProperty ContextType;
         SerializedProperty CompatibleData;
         SerializedProperty Attributes;
+        SerializedProperty CustomAttributes;
         SerializedProperty Properties;
         SerializedProperty UseTotalTime;
         SerializedProperty UseDeltaTime;
@@ -21,6 +22,7 @@ namespace UnityEditor.VFX.Block
         SerializedProperty SourceCode;
 
         ReorderableList attributeList;
+        ReorderableList customAttributeList;
         ReorderableList propertiesList;
 
         bool dirty;
@@ -31,10 +33,12 @@ namespace UnityEditor.VFX.Block
             ContextType = serializedObject.FindProperty("ContextType");
             CompatibleData = serializedObject.FindProperty("CompatibleData");
             Attributes = serializedObject.FindProperty("Attributes");
+            CustomAttributes = serializedObject.FindProperty("CustomAttributes");
             Properties = serializedObject.FindProperty("Properties");
             UseTotalTime = serializedObject.FindProperty("UseTotalTime");
             UseDeltaTime = serializedObject.FindProperty("UseDeltaTime");
             UseRandom = serializedObject.FindProperty("UseRandom");
+
             SourceCode = serializedObject.FindProperty("SourceCode");
             source = SourceCode.stringValue;
             dirty = false;
@@ -48,6 +52,16 @@ namespace UnityEditor.VFX.Block
                 attributeList.onRemoveCallback = OnRemoveAttribute;
                 attributeList.drawElementCallback = OnDrawAttribute;
                 attributeList.onReorderCallback = OnReorderAttribute;
+            }
+
+            if (customAttributeList == null)
+            {
+                customAttributeList = new ReorderableList(serializedObject, CustomAttributes, true, true, true, true);
+                customAttributeList.drawHeaderCallback = (r) => { GUI.Label(r, "Custom Attributes"); };
+                customAttributeList.onAddCallback = OnAddCustomAttribute;
+                customAttributeList.onRemoveCallback = OnRemoveCustomAttribute;
+                customAttributeList.drawElementCallback = OnDrawCustomAttribute;
+                customAttributeList.onReorderCallback = OnReorderCustomAttribute;
             }
 
             if (propertiesList == null)
@@ -101,6 +115,61 @@ namespace UnityEditor.VFX.Block
             modeRect.xMin = split;
             var mode = sp.FindPropertyRelative("mode");
             var value = EditorGUI.EnumPopup(modeRect, (AttributeMode)mode.intValue);
+            mode.intValue = (int)System.Convert.ChangeType(value, typeof(AttributeMode));
+
+            if(GUI.changed)
+                Apply();
+        }
+
+        void OnAddCustomAttribute(ReorderableList list)
+        {
+            CustomAttributes.InsertArrayElementAtIndex(0);
+            var sp = CustomAttributes.GetArrayElementAtIndex(0);
+            sp.FindPropertyRelative("name").stringValue = "";
+            sp.FindPropertyRelative("type").enumValueIndex = 0; // Float
+            sp.FindPropertyRelative("mode").enumValueIndex = 3; // ReadWrite
+            dirty = true;
+            Apply();
+        }
+
+        void OnRemoveCustomAttribute(ReorderableList list)
+        {
+             if (list.index != -1)
+                CustomAttributes.DeleteArrayElementAtIndex(list.index);
+            dirty = true;
+            Apply();
+        }
+
+        void OnReorderCustomAttribute(ReorderableList list)
+        {
+            dirty = true;
+            Apply();
+        }
+
+        void OnDrawCustomAttribute(Rect rect, int index, bool isActive, bool isFocused)
+        {
+            var sp = CustomAttributes.GetArrayElementAtIndex(index);
+            rect.yMin += 2;
+            rect.height = 16;
+            float split = rect.width / 3;
+
+            var nameRect = rect;    
+            nameRect.width = split - 1;
+            string name = sp.FindPropertyRelative("name").stringValue;
+            sp.FindPropertyRelative("name").stringValue = EditorGUI.DelayedTextField(nameRect, name);
+
+            var typeRect = rect;
+            typeRect.xMin = nameRect.xMax + 2;
+            typeRect.width = split - 1;
+            var type = sp.FindPropertyRelative("type");
+            var value = EditorGUI.EnumPopup(typeRect, (CustomAttributeUtility.Signature) type.intValue);
+            type.intValue = (int)System.Convert.ChangeType(value, typeof(CustomAttributeUtility.Signature));
+
+            var modeRect = rect;
+            modeRect.xMin = typeRect.xMax + 2;
+            modeRect.width = split - 1;
+            var mode = sp.FindPropertyRelative("mode");
+            value = EditorGUI.EnumPopup(modeRect, (AttributeMode) mode.intValue);
             mode.intValue = (int)System.Convert.ChangeType(value, typeof(AttributeMode));
 
             if(GUI.changed)
@@ -177,6 +246,7 @@ namespace UnityEditor.VFX.Block
             EditorGUILayout.PropertyField(ContextType);
             EditorGUILayout.PropertyField(CompatibleData);
             attributeList.DoLayoutList();
+            customAttributeList.DoLayoutList();
             propertiesList.DoLayoutList(); 
 
             EditorGUILayout.Space();
@@ -193,7 +263,10 @@ namespace UnityEditor.VFX.Block
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Source Code", EditorStyles.boldLabel);
             EditorGUI.BeginChangeCheck();
-            source = EditorGUILayout.TextArea(source, Styles.codeEditor, GUILayout.MinHeight(64));
+            source = EditorGUILayout.TextArea(source, Styles.codeEditor, new GUILayoutOption[] {
+                GUILayout.MinHeight(128), 
+                GUILayout.ExpandHeight(true)
+            });
 
             if (EditorGUI.EndChangeCheck())
                 dirty = true;
@@ -202,6 +275,7 @@ namespace UnityEditor.VFX.Block
             {
                 if (GUILayout.Button("Apply"))
                 {
+                    // TODO: load here the source code (as string) from the specified file
                     SourceCode.stringValue = source;
                     Apply();
                 }


### PR DESCRIPTION
Hi peeweek,

for my use case I needed to be able to access custom attributes within the custom source code and I didn't see the option in the attribute selection, so I implemented it. 
I've only tested it with write access to a custom float attribute - it works.

The user can specify his custom attribute with a string - similar to the Get/Set Custom Attribute Operators. Additionally the type of the custom attribute has to be specified, the options for that are directly pulled from the CustomAttributeUtility.

If there's anything off let me know.

New UI:
![image](https://user-images.githubusercontent.com/63500142/159098252-773ea50d-d6aa-439d-bd34-f96acebc8deb.png)
